### PR TITLE
Improved property tests with null examples that reveals bugs

### DIFF
--- a/src/test/java/org/cellx/logishTest/IntMapTests.java
+++ b/src/test/java/org/cellx/logishTest/IntMapTests.java
@@ -23,6 +23,7 @@ public class IntMapTests {
     public void testInsertion(HashSet<@InRange(min = "0", max = "100") Integer> set) {
         // Insert all values into a map
         final IntMap<Integer> map = IntMap.ofAll(set, i -> IntMap.entry(i, i));
+        map.withAll(set, i -> IntMap.entry(i+100, null));
         // Make sure the tree is balanced
         map.checkConsistency();
         // Compare the map and the set
@@ -36,14 +37,18 @@ public class IntMapTests {
         for (int i=0; i<=100; i++) set.add(i);
 
         final IntMap<Integer> fullMap = IntMap.ofAll(set, i -> IntMap.entry(i, i));
+        final IntMap<Integer> emptyMap = IntMap.empty();
 
         set.removeAll(minusSet);
 
         final IntMap<Integer> reducedMap = fullMap.withoutKeys(minusSet, i -> i);
+        final IntMap<Integer> anotherEmptyMap = emptyMap.withoutKeys(minusSet, i -> i);
 
         reducedMap.checkConsistency();
+        anotherEmptyMap.checkConsistency();
 
         compareMapKeysAndSet(reducedMap, set);
+        compareMapKeysAndSet(anotherEmptyMap, new TreeSet<>());
     }
 
     protected  <V> void compareMapKeysAndSet(IntMap<V> map, Set<Integer> set) {


### PR DESCRIPTION
Hi!

In an effort to improve the coverage of the property tests, I improved the existing property tests to test `null` handling and found some bugs:
* `testInsertion` adds a bunch of keys mapping to `null` that cause a `NullPointerException` when balancing the tree:
```
Caused by: java.lang.NullPointerException                                                                 
        at org.cellx.logish.IntMap$Node.balanceLeft(IntMap.java:614)                                                                                                                                                
        at org.cellx.logish.IntMap$Node.without(IntMap.java:686)                                                                                                                                                    
        at org.cellx.logish.IntMap$Node.with(IntMap.java:641)                                                                                                                                                       
        at org.cellx.logish.IntMap.withAll(IntMap.java:338)                                                                                                                                                         
        at org.cellx.logishTest.IntMapTests.testInsertion(IntMapTests.java:26)    
```
* `testDeletion` attempts to delete keys from an empty map, which also causes `NullPointerException` as the delete operation sometimes returns an empty map and other times returns `null`:
```
Caused by: java.lang.NullPointerException                                                                 
        at org.cellx.logishTest.IntMapTests.testDeletion(IntMapTests.java:48)   
```

More info on how to replicate these issues:
```
[ERROR] Failures:                                                                                         
[ERROR]   IntMapTests.testDeletion Unexpected error in property testDeletion with args [[15]] and seeds [6787329991909443937]                                                                                       
[ERROR]   IntMapTests.testInsertion Unexpected error in property testInsertion with args [[83]] and seeds [3090420391447367513]

```